### PR TITLE
Revert "Adding node config so it can run from Gradle. "

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,25 +5,12 @@ plugins {
 
 node {
     nodeModulesDir = file("${rootProject.projectDir}/app/launch")
-
-    // Version of node to use.
-    version = '20.2.0'
-
-    // Version of npm to use.
-    npmVersion = '7.0.7'
-    download = true
 }
 
 task buildStarter(type: NpmTask) {
     dependsOn npmInstall
     workingDir = file("${rootProject.projectDir}/app/launch")
-    args = ['config', 'set', 'script-shell', '/usr/bin/bash', 'run', 'build']
-}
-
-
-task run(type: NpmTask, dependsOn: buildStarter) {
-  description = "Build Project run"
-args = ["run", "start:local"]
+    args = ['run', 'build']
 }
 
 npmInstall.configure {


### PR DESCRIPTION
Reverts grails/grails-forge-ui#18

It appears that `publish.sh` is failing with following error, so reverted this change.

```
Run ./publish.sh
Downloading https://services.gradle.org/distributions/gradle-7.6.3-bin.zip
...........[10](https://github.com/grails/grails-forge-ui/actions/runs/6865215175/job/18668695508#step:5:11)%............20%...........30%............40%............50%...........60%............70%............80%...........90%............100%

Welcome to Gradle 7.6.3!

Here are the highlights of this release:
 - Added support for Java 19.
 - Introduced `--rerun` flag for individual task rerun.
 - Improved dependency block for test suites to be strongly typed.
 - Added a pluggable system for Java toolchains provisioning.

For more details see https://docs.gradle.org/7.6.3/release-notes.html

Starting a Gradle Daemon (subsequent builds will be faster)
> Task :assemble UP-TO-DATE
> Task :check UP-TO-DATE
> Task :nodeSetup

> Task :npmSetup

added 1 package in 1s

10 packages are looking for funding
  run `npm fund` for details

npm WARN deprecated fsevents@1.2.13: fsevents 1 will break on node v14+ and could be using insecure binaries. Upgrade to fsevents 2.
> Task :npmInstall
npm WARN deprecated uuid@3.4.0: Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.
npm WARN deprecated fsevents@1.2.13: fsevents 1 will break on node v14+ and could be using insecure binaries. Upgrade to fsevents 2.
npm WARN deprecated chokidar@2.1.8: Chokidar 2 does not receive security updates since 2019. Upgrade to chokidar 3 with 15x fewer dependencies
npm WARN deprecated querystring@0.2.0: The querystring API is considered Legacy. new code should use the URLSearchParams API instead.
npm WARN deprecated urix@0.1.0: Please see https://github.com/lydell/urix#deprecated
npm WARN deprecated chokidar@2.1.8: Chokidar 2 does not receive security updates since 2019. Upgrade to chokidar 3 with 15x fewer dependencies
npm WARN deprecated w3c-hr-time@1.0.2: Use your platform's native performance.now() and performance.timeOrigin.
npm WARN deprecated stable@0.1.8: Modern JS already guarantees Array#sort() is a stable sort, so this library is deprecated. See the compatibility table on MDN: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort#browser_compatibility
npm WARN deprecated sourcemap-codec@1.4.8: Please use @jridgewell/sourcemap-codec instead
npm WARN deprecated source-map-url@0.4.1: See https://github.com/lydell/source-map-url#deprecated
npm WARN deprecated source-map-resolve@0.5.3: See https://github.com/lydell/source-map-resolve#deprecated
npm WARN deprecated uuid@3.4.0: Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.
npm WARN deprecated sane@4.1.0: some dependency vulnerabilities fixed, support for node < 10 dropped, and newer ECMAScript syntax/features added
npm WARN deprecated rollup-plugin-terser@5.3.1: This package has been deprecated and is no longer maintained. Please use @rollup/plugin-terser
npm WARN deprecated resolve-url@0.2.1: https://github.com/lydell/resolve-url#deprecated
npm WARN deprecated rollup-plugin-babel@4.4.0: This package has been deprecated and is no longer maintained. Please use @rollup/plugin-babel.
npm WARN deprecated querystring@0.2.1: The querystring API is considered Legacy. new code should use the URLSearchParams API instead.
npm WARN deprecated svgo@1.3.2: This SVGO version is no longer supported. Upgrade to v2.x.x.
npm WARN deprecated flatten@1.0.3: flatten is deprecated in favor of utility frameworks such as lodash.
npm WARN deprecated babel-eslint@10.1.0: babel-eslint is now @babel/eslint-parser. This package will no longer receive updates.
npm WARN deprecated @npmcli/move-file@1.1.2: This functionality has been moved to @npmcli/fs
npm WARN deprecated @hapi/topo@3.1.6: This version has been deprecated and is no longer supported or maintained
npm WARN deprecated @hapi/bourne@1.3.2: This version has been deprecated and is no longer supported or maintained
npm WARN deprecated @hapi/address@2.1.4: Moved to 'npm install @sideway/address'
npm WARN deprecated @hapi/hoek@8.5.1: This version has been deprecated and is no longer supported or maintained
npm WARN deprecated @hapi/joi@15.1.1: Switch to 'npm install joi'
npm WARN deprecated @material-ui/system@4.[11](https://github.com/grails/grails-forge-ui/actions/runs/6865215175/job/18668695508#step:5:12).3: You can now upgrade to @mui/system. See the guide: https://mui.com/guides/migration-v4/
npm WARN deprecated @material-ui/styles@4.11.4: Material UI v4 doesn't receive active development since September 2021. See the guide https://mui.com/material-ui/migration/migration-v4/ to upgrade to v5.
npm WARN deprecated @material-ui/lab@4.0.0-alpha.58: Material UI v4 doesn't receive active development since September 2021. See the guide https://mui.com/material-ui/migration/migration-v4/ to upgrade to v5.
npm WARN deprecated core-js@2.6.[12](https://github.com/grails/grails-forge-ui/actions/runs/6865215175/job/18668695508#step:5:13): core-js@<3.23.3 is no longer maintained and not recommended for usage due to the number of issues. Because of the V8 engine whims, feature detection in old core-js versions could cause a slowdown up to 100x even if nothing is polyfilled. Some versions have web compatibility issues. Please, upgrade your dependencies to the actual version of core-js.
npm WARN deprecated core-js@3.[16](https://github.com/grails/grails-forge-ui/actions/runs/6865215175/job/18668695508#step:5:17).1: core-js@<3.23.3 is no longer maintained and not recommended for usage due to the number of issues. Because of the V8 engine whims, feature detection in old core-js versions could cause a slowdown up to 100x even if nothing is polyfilled. Some versions have web compatibility issues. Please, upgrade your dependencies to the actual version of core-js.
npm WARN deprecated core-js-pure@3.16.1: core-js-pure@<3.23.3 is no longer maintained and not recommended for usage due to the number of issues. Because of the V8 engine whims, feature detection in old core-js versions could cause a slowdown up to 100x even if nothing is polyfilled. Some versions have web compatibility issues. Please, upgrade your dependencies to the actual version of core-js-pure.
npm WARN deprecated @material-ui/core@4.11.4: Material UI v4 doesn't receive active development since September 2021. See the guide https://mui.com/material-ui/migration/migration-v4/ to upgrade to v5.
npm WARN deprecated @material-ui/icons@4.11.2: You can now upgrade to @mui/icons. See the guide: https://mui.com/guides/migration-v4/

added 1992 packages, and audited 1992 packages in 32s

[17](https://github.com/grails/grails-forge-ui/actions/runs/6865215175/job/18668695508#step:5:18)0 packages are looking for funding
  run `npm fund` for details

1[28](https://github.com/grails/grails-forge-ui/actions/runs/6865215175/job/18668695508#step:5:29) vulnerabilities (1 low, 86 moderate, [29](https://github.com/grails/grails-forge-ui/actions/runs/6865215175/job/18668695508#step:5:30) high, 12 critical)

To address issues that do not require attention, run:
  npm audit fix

To address all issues possible (including breaking changes), run:
  npm audit fix --force

Some issues need review, and may require choosing
a different dependency.

Run `npm audit` for details.

> Task :buildStarter
> Task :copyLaunchAssets
> Task :build

BUILD SUCCESSFUL in [51](https://github.com/grails/grails-forge-ui/actions/runs/6865215175/job/18668695508#step:5:52)s
5 actionable tasks: 5 executed
Cloning into 'gh-pages'...
cp: cannot stat '../build/launch/*': No such file or directory
Error: Process completed with exit code 1.
```