### PR TITLE
Update to NEW DNS

### DIFF
--- a/app/launch/public/grails-version-feed.json
+++ b/app/launch/public/grails-version-feed.json
@@ -2,12 +2,12 @@
     "versions": [
         {
             "key": "RELEASE",
-            "baseUrl": "https://grailsforge-latest-cjmq3uyfcq-uc.a.run.app",
+            "baseUrl": "https://latest.grails.org",
             "order": 0
         },
         {
             "key": "SNAPSHOT",
-            "baseUrl": "https://grailsforge-snapshot-cjmq3uyfcq-uc.a.run.app",
+            "baseUrl": "https://snapshot.grails.org",
             "order": 1                    
         },
         {

--- a/dev-proxy-server/src/starter-dev.js
+++ b/dev-proxy-server/src/starter-dev.js
@@ -1,6 +1,6 @@
 const axios = require("axios");
 
-const VERSION_FEED_URL = "https://grailsforge-cjmq3uyfcq-uc.a.run.app/grails-version-feed.json";
+const VERSION_FEED_URL = "https://latest.grails.org/grails-version-feed.json";
 const { startVersionServer, toLocalUrl } = require("./commands");
 
 /**


### PR DESCRIPTION
Use the new endpoints https://latest.grails.org and https://snapshot.grails.org instead of the default Google Cloud generated endpoints (ending with .app)