### PR TITLE
Correct displayed commands and prefer `grails create-app`

### DIFF
--- a/app/launch/src/micronaut/creators/ToCli.js
+++ b/app/launch/src/micronaut/creators/ToCli.js
@@ -1,7 +1,13 @@
 function deriveCommand(type) {
   switch (type) {
     case 'WEB':
-      return 'create-webapp'
+      return 'create-app'
+    case 'REST_API':
+      return 'create-restapi'
+    case 'PLUGIN':
+      return 'create-plugin'
+    case 'WEB_PLUGIN':
+      return 'create-web-plugin'
     default:
       return `create-${type}`.toLowerCase()
   }


### PR DESCRIPTION
Some displayed commands were incorrect; this commit fixes them.
Additionally, it replaces the alias `grails create-webapp` with the more standard `grails create-app`.