### PR TITLE
ci: audit and update GitHub Actions to ASF-approved versions

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -14,18 +14,19 @@ jobs:
         node-version: [20.x]
     steps:
       - name: "📥 Checkout repository"
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: "☕️ Setup JDK"
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           distribution: 'liberica'
           java-version: ${{ matrix.java }}
       - name: "🐘 Setup Gradle"
-        uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.2.0
+        uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
         with:
+          cache-provider: basic # 'basic' uses the MIT-licensed, open-source cache provider; the default 'enhanced' provider (v6+) is proprietary (Gradle commercial Terms of Use)
           develocity-access-key: ${{ secrets.GRAILS_DEVELOCITY_ACCESS_KEY  }}
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: ${{ matrix.node-version }}
       - name: "🔨 Build project"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,15 +11,16 @@ jobs:
         java: ['17']
     steps:
       - name: "📥 Checkout repository"
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: "☕️ Setup JDK"
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           distribution: 'liberica'
           java-version: ${{ matrix.java }}
       - name: "🐘 Setup Gradle"
-        uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.2.0
+        uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
         with:
+          cache-provider: basic # 'basic' uses the MIT-licensed, open-source cache provider; the default 'enhanced' provider (v6+) is proprietary (Gradle commercial Terms of Use)
           develocity-access-key: ${{ secrets.GRAILS_DEVELOCITY_ACCESS_KEY  }}
       - name: Publish Grails Forge UI
         run: ./publish.sh


### PR DESCRIPTION
## What

Audit of every GitHub Action used in this repository against the [ASF approved actions allow-list](https://github.com/apache/infrastructure-actions/blob/main/actions.yml), updating each to its current approved version and pinning every external action to a full commit SHA with a trailing comment naming the version it resolves to.

This mirrors the audit performed on grails-core in apache/grails-core#15690 and brings this repository back onto supported, allow-list-approved action versions.

## Why (setup-gradle)

The primary driver is `gradle/actions/setup-gradle`:

- The previously-used SHAs were either never on the ASF allow-list or are scheduled to **expire from it on 2026-06-20**.
- `gradle/actions` `v6.0.0` moved caching into a proprietary `enhanced` provider governed by [Gradle's commercial Terms of Use](https://gradle.com/legal/terms-of-use/). `v6.1.0` reintroduced an MIT-licensed `basic` cache provider.

Standardizing on the approved **`v6.1.0`** SHA with **`cache-provider: basic`** (2 steps) keeps us on a supported version while caching stays MIT-licensed. Each `cache-provider` line carries an inline comment documenting the distinction.

## Changes

| Action | Before | After (pinned SHA # version) |
|--------|--------|------------------------------|
| `actions/checkout` | v6 | `de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2` |
| `actions/setup-java` | v5 | `be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0` |
| `gradle/actions/setup-gradle` | 0723195856401067f7a2779048b490ace7a47d7c # v5.2.0 | `50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0` |
| `actions/setup-node` | v4 | `48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0` |

Plus `cache-provider: basic` added to all 2 `setup-gradle` steps.

First-party `apache/grails-github-actions/*` references and local `./.github/actions/*` composites are intentionally left unchanged.

## Verification

- Every external action is SHA-pinned with a `# version` comment; the only non-SHA refs remaining are the first-party `apache/*` `@asf` ones and local composite actions.
- All modified workflow YAML files parse cleanly.