### PR TITLE
Skip gh-pages commit when build output is unchanged

### DIFF
--- a/publish.sh
+++ b/publish.sh
@@ -30,13 +30,13 @@ fi
 git clone https://${GH_TOKEN}@github.com/${GITHUB_SLUG}.git -b gh-pages gh-pages --single-branch > /dev/null
 cd gh-pages
 cp -r ../build/launch/* .
-#if git diff --quiet; then
-#  echo "No changes in Grails Forge UI"
-#else
 git add -A
-git commit -a -m "Updating $GITHUB_SLUG gh-pages branch for Github Actions run:$GITHUB_RUN_ID"
-git push https://oauth2:${GH_TOKEN}@github.com/${GITHUB_SLUG}.git gh-pages
-#fi
+if git diff --cached --quiet; then
+  echo "No changes in Grails Forge UI"
+else
+  git commit -m "Updating $GITHUB_SLUG gh-pages branch for Github Actions run:$GITHUB_RUN_ID"
+  git push https://oauth2:${GH_TOKEN}@github.com/${GITHUB_SLUG}.git gh-pages
+fi
 cd ..
 rm -rf gh-pages
 


### PR DESCRIPTION
## Summary
The Publish workflow has been failing on `main` whenever a merge doesn't change the built UI output (e.g. dependabot bumps to GitHub Actions versions in #125 and #128). `publish.sh` runs with `set -e`, and `git commit` exits 1 on an empty diff ("nothing to commit, working tree clean"), failing the whole run even though the build succeeded.

The no-changes guard was previously commented out. This restores it, but checks the **staged** diff after `git add -A` (`git diff --cached --quiet`) so newly added files are also detected — the old pre-add `git diff --quiet` check would have missed them.

## Testing
- `bash -n publish.sh` passes
- Behavior: identical build output → logs "No changes in Grails Forge UI" and exits 0; changed output → commits and pushes to gh-pages as before