### PR TITLE
Act on the Forge API's feature relationship metadata

### DIFF
--- a/app/launch/src/components/FeatureSelector/FeatureAvailable.jsx
+++ b/app/launch/src/components/FeatureSelector/FeatureAvailable.jsx
@@ -9,14 +9,25 @@ import {
 } from '@mui/material'
 
 const FeatureAvailable = ({ feature, toggleFeatures }) => {
+    const implied = Boolean(feature.impliedBy)
+    const disabled = Boolean(feature.conflictsWith)
+    const stateSuffix = implied
+        ? ` — included automatically by ${feature.impliedBy}`
+        : disabled
+        ? ` — unavailable with ${feature.conflictsWith}`
+        : ''
     return (
         <Card
             id={`mn-feature-${feature.name}`}
             className={`mn-feature-selection hoverable ${
                 feature.selected ? 'selected' : ''
-            }`}
+            }${implied ? ' implied' : ''}${disabled ? ' disabled' : ''}`}
             onClick={(e) => toggleFeatures(e, feature)}
-            style={{ cursor: 'pointer', position: 'relative' }}
+            style={{
+                cursor: implied || disabled ? 'not-allowed' : 'pointer',
+                opacity: disabled ? 0.5 : 1,
+                position: 'relative',
+            }}
         >
             <CardHeader
               title={
@@ -25,7 +36,8 @@ const FeatureAvailable = ({ feature, toggleFeatures }) => {
                     : feature.title) +
                 (feature.community != null && feature.community
                     ? ' (community)'
-                    : '')
+                    : '') +
+                stateSuffix
               }
               subheader={feature.description}
               titleTypographyProps={{

--- a/app/launch/src/components/FeatureSelector/FeatureSelected.jsx
+++ b/app/launch/src/components/FeatureSelector/FeatureSelected.jsx
@@ -1,5 +1,6 @@
 // FeatureSelected.js
 import React, { useMemo } from 'react'
+import { impliedFeatures } from '../../helpers/featureRelations'
 import {
   useAvailableFeatures,
   useSelectedFeaturesHandlers,
@@ -63,10 +64,28 @@ export function FeatureSelectedList() {
     ))
   }, [selectedFeatureValues, onRemoveFeature, availableFeatures])
 
+  const impliedRows = useMemo(() => {
+    const implied = impliedFeatures(selectedFeatures, availableFeatures)
+    return Object.entries(implied).map(([name, byTitle]) => {
+      const feature = availableFeatures.find((f) => f.name === name)
+      return (
+        <div
+          key={`implied-${name}`}
+          className="chip implied"
+          style={{ marginRight: 10, opacity: 0.7 }}
+          title={`Included automatically by ${byTitle}`}
+        >
+          {feature ? feature.title : name} (included)
+        </div>
+      )
+    })
+  }, [selectedFeatures, availableFeatures])
+
   return (
     <div className="col s12">
       <h6>Additional Selected Features ({selectedFeatureValues.length})</h6>
       {sRows}
+      {impliedRows}
     </div>
   )
 }

--- a/app/launch/src/components/FeatureSelector/FeatureSelector.jsx
+++ b/app/launch/src/components/FeatureSelector/FeatureSelector.jsx
@@ -11,6 +11,11 @@ import {
   Icon,
 } from '@mui/material'
 import messages from '../../constants/messages.json'
+import {
+  conflictingWith,
+  impliedFeatures,
+  occupiedGroups,
+} from '../../helpers/featureRelations'
 import { ModalKeyboardHandler } from '../../helpers/ModalKeyboardHandler'
 import {
   useSelectedFeatures,
@@ -69,13 +74,23 @@ export const FeatureSelectorModal = ({ theme = 'light' }) => {
 
   const selectedFeatureKeys = Object.keys(selectedFeatures)
   const availableFeatures = useMemo(() => {
+    const implied = impliedFeatures(selectedFeatures, features)
+    const groups = occupiedGroups(selectedFeatures, features)
     return features.map((feature) => {
+      const selected = selectedFeatureKeys.includes(feature.name)
+      const impliedBy = !selected ? implied[feature.name] : undefined
+      const conflict =
+        !selected && !impliedBy
+          ? conflictingWith(feature, groups, features)
+          : null
       return {
         ...feature,
-        selected: selectedFeatureKeys.includes(feature.name),
+        selected,
+        impliedBy,
+        conflictsWith: conflict,
       }
     })
-  }, [features, selectedFeatureKeys])
+  }, [features, selectedFeatures, selectedFeatureKeys])
 
   const searchResults = useMemo(() => {
     if (!search.length) {
@@ -100,6 +115,9 @@ export const FeatureSelectorModal = ({ theme = 'light' }) => {
   const toggleFeatures = (event, feature) => {
     if (event && event.preventDefault) {
       event.preventDefault()
+    }
+    if (feature.conflictsWith || feature.impliedBy) {
+      return
     }
     feature.selected ? onRemoveFeature(feature) : onAddFeature(feature)
   }

--- a/app/launch/src/helpers/featureRelations.js
+++ b/app/launch/src/helpers/featureRelations.js
@@ -1,0 +1,70 @@
+// Feature relationship metadata from the Forge API:
+// - dependentFeatures: features a selection adds automatically server-side
+// - oneOfGroup: features sharing a group are mutually exclusive
+// These helpers expand a selection so the UI can show implied features and
+// disable cards whose selection would be rejected at generation time.
+
+const byName = (availableFeatures) =>
+  availableFeatures.reduce((map, f) => {
+    map[f.name] = f
+    return map
+  }, {})
+
+const transitiveDependents = (names, lookup) => {
+  const seen = new Set(names)
+  const queue = [...names]
+  while (queue.length) {
+    const feature = lookup[queue.shift()]
+    ;(feature?.dependentFeatures || []).forEach((dep) => {
+      if (!seen.has(dep)) {
+        seen.add(dep)
+        queue.push(dep)
+      }
+    })
+  }
+  return seen
+}
+
+// Map of implied-feature name -> title of the selected feature that implies it
+// (features implied by the selection but not explicitly selected themselves).
+export const impliedFeatures = (selectedFeatures, availableFeatures) => {
+  const lookup = byName(availableFeatures)
+  const implied = {}
+  Object.keys(selectedFeatures).forEach((name) => {
+    transitiveDependents([name], lookup).forEach((dep) => {
+      if (dep !== name && !(dep in selectedFeatures) && lookup[dep]) {
+        implied[dep] = lookup[name]?.title || name
+      }
+    })
+  })
+  return implied
+}
+
+// Map of oneOfGroup -> {name, title} of the effective (selected or implied)
+// feature occupying it.
+export const occupiedGroups = (selectedFeatures, availableFeatures) => {
+  const lookup = byName(availableFeatures)
+  const effective = transitiveDependents(Object.keys(selectedFeatures), lookup)
+  const groups = {}
+  effective.forEach((name) => {
+    const feature = lookup[name]
+    if (feature?.oneOfGroup) {
+      groups[feature.oneOfGroup] = { name, title: feature.title }
+    }
+  })
+  return groups
+}
+
+// The title of the effective feature that makes this card unselectable, or
+// null when the card can be selected. A card conflicts when it - or anything
+// it would add automatically - lands in a group occupied by another feature.
+export const conflictingWith = (feature, groups, availableFeatures) => {
+  const lookup = byName(availableFeatures)
+  for (const name of transitiveDependents([feature.name], lookup)) {
+    const group = lookup[name]?.oneOfGroup
+    if (group && groups[group] && groups[group].name !== name) {
+      return groups[group].title
+    }
+  }
+  return null
+}


### PR DESCRIPTION
## Summary

The Grails Forge API now reports two relationship fields per feature (apache/grails-core#15987): `dependentFeatures` — features a selection adds automatically server-side — and `oneOfGroup` — features sharing a group are mutually exclusive. The feature selector previously surfaced neither: implied features were invisible in the selection, and conflicting features could be selected together only to fail at generation time.

A new `featureRelations` helper expands a selection transitively (a feature's dependents, their dependents, and so on), and the selector acts on it:

- **Implied features** are labelled *included automatically by <feature>* on their card, made non-toggleable, and appended to the Additional Selected Features row as non-removable *(included)* chips.
- **Conflicting features** — those whose selection, directly or through anything they would add automatically, would land in a one-of group already occupied by another feature — are greyed out and disabled, labelled *unavailable with <feature>*.

Example with the new Spring Security features: selecting **Grails Spring Security UI Plugin** shows **Grails Spring Security Plugin** as included and disables **Spring Boot Starter Security** (the conflict flows through the implied core plugin).

Features without the new metadata behave exactly as before, and the fields are absent-tolerant, so the UI works unchanged against API versions that do not ship them — the two PRs can merge independently in either order.

## Testing

- `npm run lint` clean
- `npx vitest run` — 30/30 passing
- Verified live against a local Forge API serving the metadata: implied labelling, transitive disabling, and chip rendering all as described