### PR TITLE
Remove dead GitHub create residue from Launch UI

### DIFF
--- a/app/launch/src/components/Application/App.jsx
+++ b/app/launch/src/components/Application/App.jsx
@@ -106,10 +106,6 @@ export function AppContainer({ initialData, errorHandlers }) {
   // Routing
   const routingHandlers = useMemo(() => {
     return {
-      onRepoCreated: (repoCreatedInfo) => {
-        setNextStepsInfo(repoCreatedInfo)
-      },
-
       preview: async (payload, sdk, opts = { showing: null }) => {
         try {
           const json = await sdk.preview(payload)
@@ -152,7 +148,7 @@ export function AppContainer({ initialData, errorHandlers }) {
   }, [errorHandlers])
 
   // Share Initial Routing Routing
-  useOnMountRouting(initialData, routingHandlers, errorHandlers.onResponseError)
+  useOnMountRouting(initialData, routingHandlers)
 
   // Preflight for any async activity
   const requestPrep = (event) => {
@@ -164,11 +160,6 @@ export function AppContainer({ initialData, errorHandlers }) {
   }
 
   const getFormData = useGetStarterForm()
-
-  // GitHub Clone Feat
-  const onCloneProject = async (_e) => {
-    setLoading(true)
-  }
 
   // Create Feat
   const onGenerateProject = async (e) => {
@@ -235,7 +226,6 @@ export function AppContainer({ initialData, errorHandlers }) {
                   <GenerateButtons
                     theme={theme}
                     disabled={disabled}
-                    cloneProject={onCloneProject}
                     generateProject={onGenerateProject}
                   />
                 </Grid>

--- a/app/launch/src/components/Application/useOnMountRouting.js
+++ b/app/launch/src/components/Application/useOnMountRouting.js
@@ -4,41 +4,9 @@ import { resolveActionRoute, isDeepLinkReferral } from '../../helpers/Routing'
 
 import { useCurrenSdk } from '../../state/store'
 
-export function useOnMountRouting(initialData, routingHandlers, onError) {
+export function useOnMountRouting(initialData, routingHandlers) {
   const sdk = useCurrenSdk()
-  useHandleRepoClonedRouteEvent(
-    initialData,
-    routingHandlers.onRepoCreated,
-    onError
-  )
   useHandleShareLinkRouteEffect(sdk, initialData, routingHandlers)
-}
-
-export function useHandleRepoClonedRouteEvent(
-  initialData,
-  onRepoCreated,
-  onError
-) {
-  // Use Effect Hook For Error Handling and
-  // GitHub on complete callback
-  useEffect(() => {
-    const { error, htmlUrl, cloneUrl } = initialData
-    if (!error && !htmlUrl) {
-      return // nothing more to do
-    }
-    setTimeout(() => {
-      if (cloneUrl) {
-        onRepoCreated({
-          cloneUrl,
-          htmlUrl,
-          show: true,
-          type: 'clone',
-        })
-      } else if (error) {
-        onError(new Error(error.replaceAll('+', ' ')))
-      }
-    }, 500)
-  }, [initialData, onRepoCreated, onError])
 }
 
 export function useHandleShareLinkRouteEffect(

--- a/app/launch/src/components/GenerateButtons/GenerateButtons.jsx
+++ b/app/launch/src/components/GenerateButtons/GenerateButtons.jsx
@@ -20,7 +20,6 @@ const GenerateButtons = ({
   disabled,
   theme,
   generateProject,
-  _cloneProject,
   baseUrl,
 }) => {
   const createPayload = useStarterForm()

--- a/app/launch/src/components/NextSteps/NextSteps.jsx
+++ b/app/launch/src/components/NextSteps/NextSteps.jsx
@@ -6,7 +6,6 @@ import {
   DialogContent,
   DialogTitle,
   Grid,
-  Icon,
 } from '@mui/material'
 import { useStarterForm } from '../../state/store'
 import { guessOs, osOpts, OS_WINDOWS, OS_NIX } from '../../utility'
@@ -25,25 +24,12 @@ const sortedOsOpts = osOpts.sort((a, b) => {
 
 const NextSteps = ({ info, theme = 'light', onClose, onStartOver }) => {
   const { name } = useStarterForm()
-  const { htmlUrl, cloneUrl } = info
   const [os, setOs] = useState(guessedOs)
 
   const unpackCommand = useMemo(() => {
-    switch (info.type.toLowerCase()) {
-      case 'clone': {
-        const all = `git clone ${cloneUrl}`
-        const cmd = { [OS_NIX]: all, [OS_WINDOWS]: all }
-        return { action: 'Clone the repo', cmd }
-      }
-      case 'zip': {
-        const nix = `unzip ${name}.zip`
-        const unzip = { [OS_NIX]: nix }
-        return { action: 'Unzip the archive', cmd: unzip }
-      }
-      default:
-        return null
-    }
-  }, [info.type, cloneUrl, name])
+    const nix = `unzip ${name}.zip`
+    return { action: 'Unzip the archive', cmd: { [OS_NIX]: nix } }
+  }, [name])
 
   const cdCommand = useMemo(() => {
     const cd = `cd ${name}`
@@ -90,33 +76,17 @@ const NextSteps = ({ info, theme = 'light', onClose, onStartOver }) => {
           ))}
         </div>
 
-        {htmlUrl && (
-          <div className="next-steps-wrapper">
-            <h5 className="heading">View your new repo on GitHub</h5>
+        <div className="next-steps-wrapper">
+          <h5 className="heading">{unpackCommand.action}</h5>
+          {unpackCommand.cmd[os] && (
             <Grid container className="next-steps-row">
-              <Grid className="text">{htmlUrl}</Grid>
+              <Grid className="text">{unpackCommand.cmd[os]}</Grid>
               <Grid className="icon">
-                <a target="_blank" rel="noopener noreferrer" href={htmlUrl}>
-                  <Icon>link</Icon>
-                </a>
+                <CopyToClipboard value={unpackCommand.cmd[os]} />
               </Grid>
             </Grid>
-          </div>
-        )}
-
-        {unpackCommand && (
-          <div className="next-steps-wrapper">
-            <h5 className="heading">{unpackCommand.action}</h5>
-            {unpackCommand.cmd[os] && (
-              <Grid container className="next-steps-row">
-                <Grid className="text">{unpackCommand.cmd[os]}</Grid>
-                <Grid className="icon">
-                  <CopyToClipboard value={unpackCommand.cmd[os]} />
-                </Grid>
-              </Grid>
-            )}
-          </div>
-        )}
+          )}
+        </div>
 
         <div className="next-steps-wrapper">
           <h5 className="heading">cd into the project</h5>

--- a/app/launch/src/components/NextSteps/__tests__/NextSteps.test.jsx
+++ b/app/launch/src/components/NextSteps/__tests__/NextSteps.test.jsx
@@ -1,0 +1,23 @@
+import React from 'react'
+import { fireEvent, render, screen } from '@testing-library/react'
+import { vi } from 'vitest'
+
+import NextSteps from '../NextSteps'
+
+vi.mock('../../../state/store', () => ({
+  useStarterForm: () => ({ name: 'sample-app' }),
+}))
+
+it('shows ZIP unpack instructions without GitHub repository details', () => {
+  render(
+    <NextSteps
+      info={{ show: true, type: 'zip' }}
+      onClose={vi.fn()}
+      onStartOver={vi.fn()}
+    />
+  )
+
+  expect(screen.getByText('Unzip the archive')).toBeTruthy()
+  fireEvent.click(screen.getByRole('button', { name: 'Unix/Linux/macOS' }))
+  expect(screen.getByText('unzip sample-app.zip')).toBeTruthy()
+})

--- a/app/launch/src/constants/messages.json
+++ b/app/launch/src/constants/messages.json
@@ -6,7 +6,6 @@
         "diff": "Show the changes that the selected features have on an application generated without any features selected",
         "features": "Choose the features you would like included in the application",
         "generate": "Download a zip file of the application",
-        "createRepo": "Create a repo on GitHub with this configuration.",
         "preview": "Explore the application source files with the selected options and features to see what will be generated",
         "share": "Share this application configuration"
     },

--- a/app/launch/src/micronaut/MicronautStarterSDK.jsx
+++ b/app/launch/src/micronaut/MicronautStarterSDK.jsx
@@ -145,32 +145,8 @@ export class MicronautStarterSDK {
     return this.get(createCommand.toUrl('create')).then(responseHandler('blob'))
   }
 
-  /**
-   * Get The HREF for the clone to github feature.
-   * @param  {Object} configuration command parameters
-   * @return {String} The link will begin processing the github workflow with redirects
-   */
-  gitHubHref(configuration) {
-    const createCommand = new CreateCommand(configuration, this.baseUrl)
-    return createCommand.toUrl('github')
-  }
-
   static createCommand(configuration, baseUrl) {
     return new CreateCommand(configuration, baseUrl)
-  }
-
-  /**
-   * Get The HREF for the clone to github feature.
-   * @param {String} baseUrl The base URL
-   * @param  {Object} configuration The create command data
-   * @return {String} The link will begin processing the github workflow with redirects
-   */
-  static githubHrefForUrl(baseUrl, configuration) {
-    if (!baseUrl) {
-      return '#'
-    }
-    const createCommand = new CreateCommand(configuration, baseUrl)
-    return createCommand.toUrl('github')
   }
 
   static curlCommand(baseUrl, configuration) {

--- a/app/launch/src/micronaut/creators/ToUrl.js
+++ b/app/launch/src/micronaut/creators/ToUrl.js
@@ -30,7 +30,7 @@ export default class ToUrl {
   static make(createCommand, prefix) {
     if (!prefix) {
       console.error(
-        "A prefix is required, should be one of 'diff', 'preview', 'github', 'create'"
+        "A prefix is required, should be one of 'diff', 'preview', 'create'"
       )
     }
     const {

--- a/app/launch/src/state/factories/initializeState.js
+++ b/app/launch/src/state/factories/initializeState.js
@@ -31,13 +31,8 @@ function initialVersionResolver(query = {}) {
 }
 
 function extractAccessoryData(query = {}) {
-  const { debug, cloneUrl, htmlUrl, error, showing } = query
+  const { debug, showing } = query
   return {
-    // Clone To GH Related Keys
-    cloneUrl,
-    htmlUrl,
-    error,
-
     // Code Preview Related Keys
     showing,
 

--- a/app/launch/src/state/store.js
+++ b/app/launch/src/state/store.js
@@ -137,11 +137,6 @@ export const useAppStore = create((set, get) => ({
       features,
     })
   },
-  getGitHubLink: () => {
-    const form = get().getStarterForm()
-    const baseUrl = get().getBaseUrl()
-    return StarterSDK.githubHrefForUrl(baseUrl, form)
-  },
   getCreateCommand: () => {
     const form = get().getStarterForm()
     const baseUrl = get().getBaseUrl()
@@ -280,25 +275,6 @@ export function useCurrenSdk() {
 
 export function useInitialData() {
   return useAppStore((s) => s.initialValues)
-}
-
-export function useGitHubShareLink() {
-  const selectedVersion = useAppStore((s) => s.selectedVersion)
-  const appType = useAppStore((s) => s.appType)
-  const name = useAppStore((s) => s.name)
-  const pkg = useAppStore((s) => s.package)
-  const servlet = useAppStore((s) => s.servlet)
-  const gorm = useAppStore((s) => s.gorm)
-  const reloading = useAppStore((s) => s.reloading)
-  const javaVersion = useAppStore((s) => s.javaVersion)
-  const features = useAppStore((s) => s.features)
-  return useMemo(() => {
-    const form = setStorageValue(INITIAL_FORM_DATA_STORAGE_KEY, {
-      type: appType, name, package: pkg, javaVersion, gorm, servlet, reloading, features,
-    })
-    const baseUrl = selectedVersion?.api
-    return StarterSDK.githubHrefForUrl(baseUrl, form)
-  }, [selectedVersion, appType, name, pkg, servlet, gorm, reloading, javaVersion, features])
 }
 
 export function useSharableLink() {


### PR DESCRIPTION
## Summary

Follow-up to [apache/grails-core#15812](https://github.com/apache/grails-core/pull/15812), which removed the Forge server-side GitHub create/OAuth stack.

The Launch UI already dropped the **Push to GitHub** button in #61, but leftover dead code remained (GitHub href helpers, OAuth callback route handling, clone NextSteps, `createRepo` tooltip). This PR removes that residue so the UI matches the API.

## Changes

- Remove `getGitHubLink` / `useGitHubShareLink` and SDK `githubHref*` helpers
- Remove GitHub OAuth callback route handling (`useHandleRepoClonedRouteEvent`)
- Remove dead `onCloneProject` / `cloneProject` wiring
- Simplify `NextSteps` to zip-only post-generate flow
- Drop unused `createRepo` tooltip message
- Add `NextSteps` unit test for zip unpack instructions

## Intentionally kept

- Footer / marketing links to GitHub org repos (`GitHubLink`, `AltFooter`)
- Share deep-links for preview / diff / create (zip)

## Test plan

- [x] `npm test` (31 tests)
- [x] `npm run lint`
